### PR TITLE
Fixed jerky remote avatar movements, relieves network transmission

### DIFF
--- a/Assets/UXR_Multiplayer/SG_UXRAvatarNetworked.cs
+++ b/Assets/UXR_Multiplayer/SG_UXRAvatarNetworked.cs
@@ -37,15 +37,12 @@ public class SG_UXRAvatarNetworked : MonoBehaviourPun,IPunObservable
         UxrManager.AvatarsUpdated -= UxrManagerOnAvatarsUpdated;
     }
 
-    private void LateUpdate()
+    private void Update()
     {
-        if (avatar.AvatarController is UxrStandardAvatarController controller && photonView.IsMine)
+        if (avatar.AvatarMode == UxrAvatarMode.UpdateExternally &&
+            avatar.AvatarController is UxrStandardAvatarController controller)
         {
-            if (photonView == null)
-            {
-                controller.gameObject.GetPhotonView();
-            }
-            photonView.RPC("UpdateIkRPC",RpcTarget.Others);
+            controller.SolveBodyIK();
         }
     }
 
@@ -93,17 +90,6 @@ public class SG_UXRAvatarNetworked : MonoBehaviourPun,IPunObservable
 
        avatar.SetCurrentHandPose(handSide, (string)vars[1], (float)vars[2], (bool)vars[3]);
     }
-    
-    [PunRPC]
-    public void UpdateIkRPC()
-    {
-        if (avatar.AvatarController is UxrStandardAvatarController controller)
-        {
-            Debug.Log(controller.name + ": Getting IK prompt");
-            controller.SolveBodyIK();
-        }
-    }
-
 
     public void OnPhotonSerializeView(PhotonStream stream, PhotonMessageInfo info)
     {

--- a/Assets/UXR_Multiplayer/SG_UXRAvatarNetworked.cs
+++ b/Assets/UXR_Multiplayer/SG_UXRAvatarNetworked.cs
@@ -29,12 +29,12 @@ public class SG_UXRAvatarNetworked : MonoBehaviourPun,IPunObservable
     private void OnEnable()
     {
         avatar.StateChanged += StateChanged;
-        UxrManager.AvatarsUpdated += UxrManagerOnAvatarsUpdated;
+        // UxrManager.AvatarsUpdated += UxrManagerOnAvatarsUpdated;
     }
     private void OnDisable()
     {
         avatar.StateChanged -= StateChanged;
-        UxrManager.AvatarsUpdated -= UxrManagerOnAvatarsUpdated;
+        // UxrManager.AvatarsUpdated -= UxrManagerOnAvatarsUpdated;
     }
 
     private void Update()
@@ -73,6 +73,7 @@ public class SG_UXRAvatarNetworked : MonoBehaviourPun,IPunObservable
             }
         }
     }
+    
     private void UxrManagerOnAvatarsUpdated()
     {
         


### PR DESCRIPTION
- calls controller.SolveBodyIK directly on the remote (external avatar) instead of syncing the "UpdateIkRPC" PunRPC-call over the Network
- results in totally smooth movements and relieves network transmission
- with PunRPC the update happens delayed and not every frame > resulting in jerky avatar movement